### PR TITLE
fix: prevent HUD rendering when HUD is hidden

### DIFF
--- a/src/main/java/xyz/nifeather/morph/client/graphics/hud/HudRenderHelper.java
+++ b/src/main/java/xyz/nifeather/morph/client/graphics/hud/HudRenderHelper.java
@@ -2,6 +2,7 @@ package xyz.nifeather.morph.client.graphics.hud;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.shedaniel.math.Color;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderTickCounter;
 import xyz.nifeather.morph.client.ClientMorphManager;
@@ -96,7 +97,7 @@ public class HudRenderHelper extends MorphClientObject
 
     public void onRender(DrawContext context, RenderTickCounter renderTickCounter)
     {
-        if (manager == null || drawAlpha.get() == 0f) return;
+        if (manager == null || drawAlpha.get() == 0f || MinecraftClient.getInstance().options.hudHidden) return;
 
         var matrices = context.getMatrices();
 


### PR DESCRIPTION
This hides the bar in the bottom left that displays the disguise status when the player presses F1 to hide the HUD. Currently the bar is still visible.